### PR TITLE
Fix splitting headers key/value when more than one equal sign there #23

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -212,10 +212,10 @@ func decodeKeyPairs(list []string) (map[string]string, error) {
 
 	for _, x := range list {
 		items := strings.Split(x, "=")
-		if len(items) != 2 {
+		if len(items) < 2 || items[0] == "" {
 			return kp, fmt.Errorf("invalid tag '%s' should be key=pair", x)
 		}
-		kp[items[0]] = items[1]
+		kp[items[0]] = strings.Join(items[1:], "=")
 	}
 
 	return kp, nil

--- a/utils_test.go
+++ b/utils_test.go
@@ -47,6 +47,26 @@ func TestDecodeKeyPairs(t *testing.T) {
 			Ok: true,
 		},
 		{
+			List: []string{"a=b==", "b=3"},
+			KeyPairs: map[string]string{
+				"a": "b==",
+				"b": "3",
+			},
+			Ok: true,
+		},
+		{
+			List: []string{"a=", "b=3"},
+			KeyPairs: map[string]string{
+				"a": "",
+				"b": "3",
+			},
+			Ok: true,
+		},
+		{
+			List: []string{"a=b", "==b==3=="},
+			Ok:   false,
+		},
+		{
 			List: []string{"add", "b=3"},
 		},
 	}


### PR DESCRIPTION
related to #23 