### PR TITLE
New configuration to pass in a custom Error Page (for http.StatusBadRequest)

### DIFF
--- a/config.go
+++ b/config.go
@@ -220,3 +220,8 @@ func (r *Config) hasCustomSignInPage() bool {
 func (r *Config) hasCustomForbiddenPage() bool {
 	return r.ForbiddenPage != ""
 }
+
+// hasCustomErrorPage checks if there is a custom error page
+func (r *Config) hasCustomErrorPage() bool {
+	return r.ErrorPage != ""
+}

--- a/doc.go
+++ b/doc.go
@@ -342,6 +342,8 @@ type Config struct {
 	SignInPage string `json:"sign-in-page" yaml:"sign-in-page" usage:"path to custom template displayed for signin"`
 	// ForbiddenPage is a access forbidden page
 	ForbiddenPage string `json:"forbidden-page" yaml:"forbidden-page" usage:"path to custom template used for access forbidden"`
+	// ErrorPage is the relative url for the custom error page
+	ErrorPage string `json:"error-page" yaml:"error-page" usage:"path to custom template displayed for http.StatusBadRequest"`
 	// Tags is passed to the templates
 	Tags map[string]string `json:"tags" yaml:"tags" usage:"keypairs passed to the templates at render,e.g title=Page"`
 

--- a/handlers.go
+++ b/handlers.go
@@ -109,7 +109,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 	// step: ensure we have a authorization code
 	code := req.URL.Query().Get("code")
 	if code == "" {
-		w.WriteHeader(http.StatusBadRequest)
+		r.accessError(w, req)
 		return
 	}
 
@@ -477,7 +477,7 @@ func (r *oauthProxy) logoutHandler(w http.ResponseWriter, req *http.Request) {
 	// @step: drop the access token
 	user, err := r.getIdentity(req)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		r.accessError(w, req)
 		return
 	}
 
@@ -624,7 +624,7 @@ func (r *oauthProxy) expirationHandler(w http.ResponseWriter, req *http.Request)
 func (r *oauthProxy) tokenHandler(w http.ResponseWriter, req *http.Request) {
 	user, err := r.getIdentity(req)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		r.accessError(w, req)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/misc.go
+++ b/misc.go
@@ -82,6 +82,20 @@ func (r *oauthProxy) accessForbidden(w http.ResponseWriter, req *http.Request) c
 	return r.revokeProxy(w, req)
 }
 
+// accessError redirects the user to the error page
+func (r *oauthProxy) accessError(w http.ResponseWriter, req *http.Request) context.Context {
+	w.WriteHeader(http.StatusBadRequest)
+	// are we using a custom http template for 400?
+	if r.config.hasCustomErrorPage() {
+		name := path.Base(r.config.ErrorPage)
+		if err := r.Render(w, name, r.config.Tags); err != nil {
+			r.log.Error("failed to render the template", zap.Error(err), zap.String("template", name))
+		}
+	}
+
+	return r.revokeProxy(w, req)
+}
+
 // redirectToURL redirects the user and aborts the context
 func (r *oauthProxy) redirectToURL(url string, w http.ResponseWriter, req *http.Request, statusCode int) context.Context {
 	w.Header().Add("Cache-Control", "no-cache, no-store, must-revalidate, max-age=0")

--- a/server.go
+++ b/server.go
@@ -651,6 +651,11 @@ func (r *oauthProxy) createTemplates() error {
 		list = append(list, r.config.ForbiddenPage)
 	}
 
+	if r.config.ErrorPage != "" {
+		r.log.Debug("loading the custom error page", zap.String("page", r.config.ErrorPage))
+		list = append(list, r.config.ErrorPage)
+	}
+
 	if len(list) > 0 {
 		r.log.Info("loading the custom templates", zap.String("templates", strings.Join(list, ",")))
 		r.templates = template.Must(template.ParseFiles(list...))

--- a/server_test.go
+++ b/server_test.go
@@ -342,6 +342,48 @@ func TestForbiddenTemplate(t *testing.T) {
 	newFakeProxy(cfg, &fakeAuthConfig{}).RunTests(t, requests)
 }
 
+func TestErrorTemplate(t *testing.T) {
+	cfg := newFakeKeycloakConfig()
+	cfg.ErrorPage = "templates/error.html.tmpl"
+	requests := []fakeRequest{
+		{
+			URI:                     "/oauth/callback",
+			Redirects:               true,
+			ExpectedCode:            http.StatusBadRequest,
+			ExpectedContentContains: "400 Bad Request",
+		},
+	}
+	newFakeProxy(cfg, &fakeAuthConfig{}).RunTests(t, requests)
+}
+
+func TestErrorTemplateWithError(t *testing.T) {
+	cfg := newFakeKeycloakConfig()
+	cfg.ErrorPage = "templates/error-bad-formatted.html.tmpl"
+	requests := []fakeRequest{
+		{
+			URI:                     "/oauth/callback",
+			Redirects:               true,
+			ExpectedCode:            http.StatusBadRequest,
+			ExpectedContentContains: "",
+		},
+	}
+	newFakeProxy(cfg, &fakeAuthConfig{}).RunTests(t, requests)
+}
+
+func TestEmptyErrorTemplate(t *testing.T) {
+	cfg := newFakeKeycloakConfig()
+	cfg.ErrorPage = ""
+	requests := []fakeRequest{
+		{
+			URI:                     "/oauth/callback",
+			Redirects:               true,
+			ExpectedCode:            http.StatusBadRequest,
+			ExpectedContentContains: "",
+		},
+	}
+	newFakeProxy(cfg, &fakeAuthConfig{}).RunTests(t, requests)
+}
+
 func TestSkipOpenIDProviderTLSVerify(t *testing.T) {
 	c := newFakeKeycloakConfig()
 	c.SkipOpenIDProviderTLSVerify = true

--- a/templates/error-bad-formatted.html.tmpl
+++ b/templates/error-bad-formatted.html.tmpl
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Test with bad formatted html</p>
+<form na<e=...>
+</body>
+</html>

--- a/templates/error.html.tmpl
+++ b/templates/error.html.tmpl
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Error</title>
+  <style>
+    .oops {
+      font-size: 9em;
+      letter-spacing: 2px;
+    }
+	.message {
+      font-size: 3em;
+    }
+    .center {
+      margin-left: auto;
+      margin-right: auto;
+    }
+  </style>
+</head>
+<body>
+  <table class="center">
+    <tr>
+      <th class="oops">Oops!</th>
+    </tr>
+    <tr>
+      <th class="message">400 Bad Request</th>
+    </tr>
+    <tr>
+      <th>Sorry, an error has occured, please contact your administrator</th>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
# Title
New configuration to pass in a custom Error Page (for http.StatusBadRequest)

## Summary 
Adding a new configuration option to pass in a custom error page. It will display this custom error page when there is a StatusBadRequest. One use case for this is that currently, we use gatekeeper as a proxy for our app X. Inside our keycloak server, we have "required user actions" set to "Terms and Conditions". That means, if it is the first time an user access app X, he will need to accept the T&C or decline. If he accepts the terms, he can login fine to app X. However, if he declines it, he gets an empty error page with "bad request".
![image](https://user-images.githubusercontent.com/17534478/110028445-3e624900-7d01-11eb-8260-70206c67d5ed.png)

If we are able to pass in an error page, the user could see a message and a link to go back to the application like:
![image](https://user-images.githubusercontent.com/17534478/110030404-ad40a180-7d03-11eb-8b68-2849040b288b.png)


## Type

[] Bug fix
[] Feature request
[X] Enhancement
[] Docs

## Why?
To improve user experience when there is a http.StatusBadRequest on the application.

## Requirements
Just pass in the new argument error-page 

## How to try it?
I created a docker container with these changes and executed it with args:
'--error-page=/config/error-page.html'
'--verbose=true'
And with the above use case (Decline of Terms and Conditions by an user) I could see the custom error page being shown, instead of an empty page.

## Checklist:
- [X] My change requires a change to the documentation or CHANGELOG.
- [X] I have updated the documentation/CHANGELOG accordingly.

