### PR TITLE
Skip auhorization header

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -315,6 +315,8 @@ type Config struct {
 	SkipAccessTokenIssuerCheck bool `json:"skip-access-token-issuer-check" yaml:"skip-access-token-issuer-check" usage:"according RFC issuer should not be checked on access token, this will be default true in future"`
 	// according RFC client id should not be checked on access token, this will be default true in future
 	SkipAccessTokenClientIDCheck bool `json:"skip-access-token-clientid-check" yaml:"skip-access-token-clientid-check" usage:"according RFC client id should not be checked on access token, this will be default true in future"`
+	// skip authorization header (e.g. if authorization header is used by application behind gatekeeper)
+	SkipAuthorizationHeader bool `json:"skip-authorization-header" yaml:"skip-authorization-header" usage:"skip authorization header (e.g. if authorization header is used by application behind gatekeeper)"`
 	// UpstreamKeepalives specifies whether we use keepalives on the upstream
 	UpstreamKeepalives bool `json:"upstream-keepalives" yaml:"upstream-keepalives" usage:"enables or disables the keepalive connections for upstream endpoint"`
 	// UpstreamTimeout is the maximum amount of time a dial will wait for a connect to complete

--- a/session.go
+++ b/session.go
@@ -29,7 +29,7 @@ import (
 func (r *oauthProxy) getIdentity(req *http.Request) (*userContext, error) {
 	var isBearer bool
 	// step: check for a bearer token or cookie with jwt token
-	access, isBearer, err := getTokenInRequest(req, r.config.CookieAccessName)
+	access, isBearer, err := getTokenInRequest(req, r.config.CookieAccessName, r.config.SkipAuthorizationHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -74,11 +74,11 @@ func (r *oauthProxy) getRefreshTokenFromCookie(req *http.Request) (string, error
 }
 
 // getTokenInRequest returns the access token from the http request
-func getTokenInRequest(req *http.Request, name string) (string, bool, error) {
+func getTokenInRequest(req *http.Request, name string, skipAuthorizationHeader bool) (string, bool, error) {
 	bearer := true
 	// step: check for a token in the authorization header
 	token, err := getTokenInBearer(req)
-	if err != nil {
+	if err != nil || skipAuthorizationHeader {
 		if err != ErrSessionNotFound {
 			return "", false, err
 		}


### PR DESCRIPTION
## Summary 

During authorization process Gatekeeper checking authorization header. But in some cases, authorization header isn't addressed to Gatekeeper itself, but to application behind Gatekeeper reverse proxy. Due to bad JWT at authorization header, Gatekeeper will refuse request.

## Type

[x] Bug fix
[] Feature request
[] Enhancement
[] Docs