### PR TITLE
[issues/94]: Support for custom cookie names

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,6 +37,8 @@ func newDefaultConfig() *Config {
 		AccessTokenDuration:           time.Duration(720) * time.Hour,
 		CookieAccessName:              accessCookie,
 		CookieRefreshName:             refreshCookie,
+		CookieOAuthStateName:          requestStateCookie,
+		CookieRequestUriName:          requestURICookie,
 		EnableAuthorizationCookies:    true,
 		EnableAuthorizationHeader:     true,
 		EnableDefaultDeny:             true,

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -34,6 +34,10 @@ encryption-key: vGcLt8ZUdPX5fXhtLZaPHZkGWHZrT6T8xKHWf5RPfqAocuiQ6nUbNHyc3oF2toO2
 cookie-access-name: kc-access
 # the name of the refresh cookie, default to kc-state
 cookie-refresh-name: kc-state
+# the name of the Oauth Token request state, defaults to OAuth_Token_Request_State
+cookie-oauth-state-name: OAuth_Token_Request_State
+# the name of the Request Uri cookie, default to request_uri
+cookie-request-uri-name: request_uri
 # the upstream endpoint which we should proxy request
 upstream-url: http://127.0.0.1:80
 # upstream-keepalives specified wheather you want keepalive on the upstream endpoint

--- a/cookies.go
+++ b/cookies.go
@@ -126,8 +126,8 @@ func (r *oauthProxy) writeStateParameterCookie(req *http.Request, w http.Respons
 		w.WriteHeader(http.StatusInternalServerError)
 	}
 	requestURI := base64.StdEncoding.EncodeToString([]byte(req.URL.RequestURI()))
-	r.dropCookie(w, req.Host, requestURICookie, requestURI, 0)
-	r.dropCookie(w, req.Host, requestStateCookie, uuid.String(), 0)
+	r.dropCookie(w, req.Host, r.config.CookieRequestUriName, requestURI, 0)
+	r.dropCookie(w, req.Host, r.config.CookieOAuthStateName, uuid.String(), 0)
 	return uuid.String()
 }
 

--- a/doc.go
+++ b/doc.go
@@ -253,6 +253,10 @@ type Config struct {
 	CookieAccessName string `json:"cookie-access-name" yaml:"cookie-access-name" usage:"name of the cookie use to hold the access token" env:"COOKIE_ACCESS_NAME"`
 	// CookieRefreshName is the name of the refresh cookie
 	CookieRefreshName string `json:"cookie-refresh-name" yaml:"cookie-refresh-name" usage:"name of the cookie used to hold the encrypted refresh token" env:"COOKIE_REFRESH_NAME"`
+	// CookieOAuthStateName is the name of the Oauth Token request state
+	CookieOAuthStateName string `json:"cookie-oauth-state-name" yaml:"cookie-oauth-state-name" usage:"name of the cookie used to hold the Oauth request state" env:"COOKIE_OAUTH_STATE_NAME"`
+	// CookieRequestUriName is the name of the Request Uri cookie
+	CookieRequestUriName string `json:"cookie-request-uri-name" yaml:"cookie-request-uri-name" usage:"name of the cookie used to hold the request uri" env:"COOKIE_REQUEST_URI_NAME"`
 	// SecureCookie enforces the cookie as secure
 	SecureCookie bool `json:"secure-cookie" yaml:"secure-cookie" usage:"enforces the cookie to be secure" env:"SECURE_COOKIE"`
 	// HTTPOnlyCookie enforces the cookie as http only

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -55,6 +55,8 @@
 |    --cookie-domain value                   | domain the access cookie is available to, defaults host header | | PROXY_COOKIE_DOMAIN
 |    --cookie-access-name value              | name of the cookie use to hold the access token | kc-access | PROXY_COOKIE_ACCESS_NAME
 |    --cookie-refresh-name value             | name of the cookie used to hold the encrypted refresh token | kc-state | PROXY_COOKIE_REFRESH_NAME
+|    --cookie-oauth-state-name value         | name of the cookie used to hold the Oauth request state | OAuth_Token_Request_State | COOKIE_OAUTH_STATE_NAME
+|    --cookie-request-uri-name value             | name of the cookie used to hold the request uri | request_uri | COOKIE_REQUEST_URI_NAME
 |    --secure-cookie                         | enforces the cookie to be secure | true | PROXY_SECURE_COOKIE
 |    --http-only-cookie                      | enforces the cookie is in http only mode | true | PROXY_HTTP_ONLY_COOKIE
 |    --same-site-cookie value                | enforces cookies to be send only to same site requests according to the policy (can be \| Strict\|Lax\|None) | Lax | PROXY_SAME_SITE_COOKIE

--- a/handlers.go
+++ b/handlers.go
@@ -59,7 +59,7 @@ func (r *oauthProxy) getRedirectionURL(w http.ResponseWriter, req *http.Request)
 		redirect = r.config.RedirectionURL
 	}
 
-	state, _ := req.Cookie(requestStateCookie)
+	state, _ := req.Cookie(r.config.CookieOAuthStateName)
 	if state != nil && req.URL.Query().Get("state") != state.Value {
 		r.log.Error("state parameter mismatch")
 		w.WriteHeader(http.StatusForbidden)
@@ -300,7 +300,7 @@ func (r *oauthProxy) oauthCallbackHandler(w http.ResponseWriter, req *http.Reque
 	// step: decode the request variable
 	redirectURI := "/"
 	if req.URL.Query().Get("state") != "" {
-		if encodedRequestURI, _ := req.Cookie(requestURICookie); encodedRequestURI != nil {
+		if encodedRequestURI, _ := req.Cookie(r.config.CookieRequestUriName); encodedRequestURI != nil {
 			decoded, _ := base64.StdEncoding.DecodeString(encodedRequestURI.Value)
 			redirectURI = string(decoded)
 		}


### PR DESCRIPTION
# Title

Support for custom cookie names

## Summary 

Add support to customize cookie names described in #94 

## Type

[] Bug fix
[x] Feature request
[] Enhancement
[] Docs

## Why?

To overcome issue with cookie conflicts, e.g. when upgrading from older version of keycloak gatekeeper https://issues.redhat.com/browse/KEYCLOAK-10668

## Requirements

Provide a custom cookie name in YAML configuration cookie-request-uri-name and cookie-oauth-state-name

## How to try it?

Observe gatekeeper sets cookies with configured names

## Checklist:

- [x] My change requires a change to the documentation or CHANGELOG.
- [x] I have updated the documentation/CHANGELOG accordingly.

