### PR TITLE
Support for SPA on the same domain

### DIFF
--- a/cookies.go
+++ b/cookies.go
@@ -119,16 +119,21 @@ func (r *oauthProxy) dropRefreshTokenCookie(req *http.Request, w http.ResponseWr
 	r.dropCookieWithChunks(req, w, r.config.CookieRefreshName, value, duration)
 }
 
-// writeStateParameterCookie sets a state parameter cookie into the response
-func (r *oauthProxy) writeStateParameterCookie(req *http.Request, w http.ResponseWriter) string {
+// writeStateParameterCookieInner sets a state parameter cookie into the response
+func (r *oauthProxy) writeStateParameterCookieInner(req *http.Request, w http.ResponseWriter, requestUriValue string) string {
 	uuid, err := uuid.NewV4()
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-	requestURI := base64.StdEncoding.EncodeToString([]byte(req.URL.RequestURI()))
+	requestURI := base64.StdEncoding.EncodeToString([]byte(requestUriValue))
 	r.dropCookie(w, req.Host, r.config.CookieRequestURIName, requestURI, 0)
 	r.dropCookie(w, req.Host, r.config.CookieOAuthStateName, uuid.String(), 0)
 	return uuid.String()
+}
+
+// writeStateParameterCookieInner helper method to set current request URL with a state parameter cookie into the response
+func (r *oauthProxy) writeStateParameterCookie(req *http.Request, w http.ResponseWriter) string {
+	return r.writeStateParameterCookieInner(req, w, req.URL.RequestURI())
 }
 
 // clearAllCookies is just a helper function for the below

--- a/misc.go
+++ b/misc.go
@@ -107,11 +107,16 @@ func (r *oauthProxy) redirectToURL(url string, w http.ResponseWriter, req *http.
 // redirectToAuthorization redirects the user to authorization handler
 func (r *oauthProxy) redirectToAuthorization(w http.ResponseWriter, req *http.Request) context.Context {
 	if r.config.NoRedirects {
+		// set Location header to descibe where authorization endpoint is
+		// otherwise it must be stored on client-side too (with "oauth-uri" config value)
+		w.Header().Set("Location", r.config.WithOAuthURI(authorizationURL))
+		
 		w.WriteHeader(http.StatusUnauthorized)
 		return r.revokeProxy(w, req)
 	}
 
 	// step: add a state referrer to the authorization page
+	// NB: in case of redirect to auth-endpoint
 	uuid := r.writeStateParameterCookie(req, w)
 	authQuery := fmt.Sprintf("?state=%s", uuid)
 


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as much details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
# Support for SPA on the same domain

## Summary 
Create ability to use Gatekeeper with some services with Bearer Auth and with SPA with cookies at the same time.
SPA must be located on the same domain to avoid cross-site references and cookies.

## Type

[] Bug fix
[] Feature request
[x] Enhancement
[] Docs

## Why?
We want to use one gateway (gatekeeper) and one auth-service (keycloak) to many services in private zone.
There are two type of clients:
1. Other services which can be clients for Keycloak itself and use bearer token authentication
2. SPA (admin UI) which can't store securities but only cookies

Because of services there is [no-redirects=true] option.
This is useful for SPA also. 

Because of AJAX (axois, XHR) requests to API. It's a very uncofortable situation to obtain 303-redirect and HTML with login page as result of request accepting JSON.
Thats why SPA catch 401 error in case of unauthentificated request. Then it get "Location" header contains path to authorization endpoint and make "full" redirect. This header is used to free SPA from dublicate this GK-setting (oauth-uri)
While processing this request GK would store "Referer" header (with page of SPA application) as "return url" after full auth-flow.
This value stored only in case of equality of domains for SPA (referer header) and API (request url).

**NB** this workflow is applied only for [no-redirects=true]

## Requirements
--

## How to try it?
--

## Documentation
 --

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

