### PR TITLE
Make possible to specify minimal TLS version

### DIFF
--- a/config.go
+++ b/config.go
@@ -148,7 +148,15 @@ func (r *Config) isValid() error {
 	if r.UseLetsEncrypt && r.LetsEncryptCacheDir == "" {
 		return fmt.Errorf("the letsencrypt cache dir has not been set")
 	}
-
+	switch strings.ToLower(r.TLSMinVersion) {
+	case "":
+	case "tlsv1.0":
+	case "tlsv1.1":
+	case "tlsv1.2":
+	case "tlsv1.3":
+	default:
+		return fmt.Errorf("invalid minimal TLS version specified")
+	}
 	if r.EnableForwarding {
 		if r.ClientID == "" {
 			return errors.New("you have not specified the client id")

--- a/doc.go
+++ b/doc.go
@@ -281,6 +281,8 @@ type Config struct {
 	TLSClientCertificate string `json:"tls-client-certificate" yaml:"tls-client-certificate" usage:"path to the client certificate for outbound connections in reverse and forwarding proxy modes" env:"TLS_CLIENT_CERTIFICATE"`
 	// SkipUpstreamTLSVerify skips the verification of any upstream tls
 	SkipUpstreamTLSVerify bool `json:"skip-upstream-tls-verify" yaml:"skip-upstream-tls-verify" usage:"skip the verification of any upstream TLS" env:"SKIP_UPSTREAM_TLS_VERIFY"`
+	// TLSMinVersion specifies server minimal TLS version
+	TLSMinVersion string `json:"tls-min-version" yaml:"tls-min-version" usage:"specify server minimal TLS version" env:"TLS_MIN_VERSION"`
 
 	// TLSAdminCertificate is the location for a tls certificate for admin https endpoint. Defaults to TLSCertificate.
 	TLSAdminCertificate string `json:"tls-admin-cert" yaml:"tls-admin-cert" usage:"path to ths TLS certificate" env:"TLS_ADMIN_CERTIFICATE"`


### PR DESCRIPTION
This pull request introduces new option `TLSMinVersion` that allows to specify minimal supported TLS version for server listener.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

