### PR TITLE
fix: token expired error message

### DIFF
--- a/oauth.go
+++ b/oauth.go
@@ -80,7 +80,7 @@ func getRefreshedToken(conf *oauth2.Config, proxyConfig *Config, t string) (jwt.
 	tkn, err := conf.TokenSource(ctx, &oauth2.Token{RefreshToken: t}).Token()
 
 	if err != nil {
-		if strings.Contains(err.Error(), "refresh token has expired") {
+		if strings.Contains(err.Error(), "invalid_grant") {
 			return jwt.JSONWebToken{}, "", "", time.Time{}, time.Duration(0), ErrRefreshTokenExpired
 		}
 		return jwt.JSONWebToken{}, "", "", time.Time{}, time.Duration(0), err


### PR DESCRIPTION
# Fix: Token expired error message

## Summary 
Bad condition during error handling.

## Type

[x] Bug fix
[] Feature request
[] Enhancement
[] Docs

## Why?
If access token expires, gatekeeper will try to refresh access token with refresh token. But if refresh token is expired, then request fails with EC 400 `invalid_grant`. It is OK according to [documentation](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2).

But gatekeeper error isn't handled properly. File `oauth.go` on line 43 contains this condition:

```
if strings.Contains(err.Error(), "refresh token has expired") {
```

But Keycloak returns 400 Bad Request with this response error message:

```
{\"error\":\"invalid_grant\",\"error_description\":\"Token is not active\"}
```

## Requirements

<!-- 
What is required to try it?
-->

## How to try it?

<!-- 
Please provide step by step how to give this PR a try
-->

## Documentation

<!-- 
Link to the documentation pull-request if necessary
-->

## Additional Information

<!-- 
Any additional information that you believe worth mentioning
-->

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.