### PR TITLE
Removed hardcoded optional scopes

### DIFF
--- a/config.go
+++ b/config.go
@@ -60,6 +60,7 @@ func newDefaultConfig() *Config {
 		RequestIDHeader:               "X-Request-ID",
 		ResponseHeaders:               make(map[string]string),
 		SameSiteCookie:                SameSiteLax,
+		Scopes:                        []string{"email", "profile"},
 		SecureCookie:                  true,
 		ServerIdleTimeout:             120 * time.Second,
 		ServerReadTimeout:             10 * time.Second,

--- a/oauth.go
+++ b/oauth.go
@@ -37,7 +37,7 @@ const (
 
 // newOAuth2Config returns a oauth2 config
 func (r *oauthProxy) newOAuth2Config(redirectionURL string) *oauth2.Config {
-	defaultScope := []string{"openid", "email", "profile"}
+	defaultScope := []string{"openid"}
 
 	conf := &oauth2.Config{
 		ClientID:     r.config.ClientID,


### PR DESCRIPTION
## Summary 

Some optional scopes which should be configurable were hardcoded (`email`, `profile`). These scopes were moved to config as default values.

> OpenID Connect defines the following scope values:
> 
>     openid
>         REQUIRED. Informs the Authorization Server that the Client is making an OpenID Connect request. If the openid scope value is not present, the behavior is entirely unspecified. 
>     profile
>         OPTIONAL. This scope value requests access to the End-User's default profile Claims, which are: name, family_name, given_name, middle_name, nickname, preferred_username, profile, picture, website, gender, birthdate, zoneinfo, locale, and updated_at. 
>     email
>        OPTIONAL. This scope value requests access to the email and email_verified Claims. 
>     address
>         OPTIONAL. This scope value requests access to the address Claim. 
>     phone
>         OPTIONAL. This scope value requests access to the phone_number and phone_number_verified Claims. 
>     offline_access
>         OPTIONAL. This scope value requests that an OAuth 2.0 Refresh Token be issued that can be used to obtain an Access >  Token that grants access to the End-User's UserInfo Endpoint even when the End-User is not present (not logged in). 

https://openid.net/specs/openid-connect-basic-1_0.html

## Type

[x] Bug fix
[] Feature request
[] Enhancement
[] Docs