### PR TITLE
add support for discovery URLs without auth prefix (#179)

### DIFF
--- a/config.go
+++ b/config.go
@@ -648,7 +648,7 @@ func (r *Config) updateDiscoveryURI() error {
 func (r *Config) updateRealm() error {
 	path := strings.Split(r.DiscoveryURI.Path, "/")
 
-	if len(path) != 4 {
+	if len(path) != 3 {
 		return fmt.Errorf("missing realm in discovery url?")
 	}
 


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as much details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
add support for discovery URLs without auth prefix (#179)
<!-- 
The same title used to create the issue (optional)
-->

## Summary

Keycloak 17 (Quarkus distribution) removes the default `auth` context path and uses no context path. Gatekeeper requires `auth` to be available, otherwise it determines the configuration as wrong and raises an error.

The official Keycloak migration guide properly states this fact: https://www.keycloak.org/migration/migrating-to-quarkus.

This bugfix will allow discovery URLs with and without `auth` prefix to be accepted by Gatekeeper.

<!-- 
A quick summary about the feature request or bug fix with issue number. Ex: Add a new logging system described in #<issue number> 
-->

## Type

[x] Bug fix
[] Feature request
[] Enhancement
[] Docs

## Why?

<!-- 
Please elaborate more on why this is needed.
-->

This fix is required to support Keycloak 17+ deployments (Quarkus distribution).

## How to try it?

<!-- 
Please provide step by step how to give this PR a try
-->

Test with Keycloak 17+.

## Documentation

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

