### PR TITLE
Improve/fix realm extract function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,34 @@
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
 
 *.swp
 .idea/

--- a/config_test.go
+++ b/config_test.go
@@ -2077,6 +2077,50 @@ func TestUpdateRealm(t *testing.T) {
 			},
 			Valid: false,
 		},
+		{
+			Name: "OKWithRelativePath",
+			Config: &Config{
+				DiscoveryURI: &url.URL{
+					Scheme: "http",
+					Host:   "127.0.0.1",
+					Path:   "/auth/realms/test",
+				},
+			},
+			Valid: true,
+		},
+		{
+			Name: "InValidDiscoveryURLWithRelativePath",
+			Config: &Config{
+				DiscoveryURI: &url.URL{
+					Scheme: "http",
+					Host:   "127.0.0.1",
+					Path:   "/auth/realms",
+				},
+			},
+			Valid: false,
+		},
+		{
+			Name: "OKWithoutRealmsPrefix",
+			Config: &Config{
+				DiscoveryURI: &url.URL{
+					Scheme: "http",
+					Host:   "127.0.0.1",
+					Path:   "/test",
+				},
+			},
+			Valid: true,
+		},
+		{
+			Name: "OKWithoutRealmsPrefixMultipleResourcesPath",
+			Config: &Config{
+				DiscoveryURI: &url.URL{
+					Scheme: "http",
+					Host:   "127.0.0.1",
+					Path:   "/auth/test",
+				},
+			},
+			Valid: true,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as many details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
# Improve/fix realm extract function 
<!-- 
The same title used to create the issue (optional)
-->

## Summary

Improve the `config.go:updateRealm` function to support discovery URI paths that use [`http-relative-path`](https://www.keycloak.org/server/all-config#_httptls) 

<!-- 
A quick summary of the feature request or bug fix with the issue number. Ex: Add a new logging system described in #<issue number> 
-->

## Type

- [x] Bug fix
- [ ] Feature request
- [x] Enhancement
- [ ] Docs

## Why?

<!-- 
Please elaborate more on why this is needed.
-->

The change made merged as part of https://github.com/gogatekeeper/gatekeeper/pull/232 breaks the use of the gatekeeper with KC deployments that use a custom relative path (`http-relative-path`)

## Requirements

<!-- 
What is required to try it?
-->

## How to try it?

<!-- 
Please provide step by step how to give this PR a try
-->

## Documentation

<!-- 
Link to the documentation pull request if necessary
-->

## Additional Information

<!-- 
Any additional information that you believe worth mentioning
-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

