### PR TITLE
add arm builds o goreleaser config (fixes #244)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,7 +20,13 @@ builds:
 
 - id: linux
   goos: [linux]
-  goarch: [amd64]
+  goarch:
+    - amd64
+    - arm
+    - arm64
+  goarm:
+    - 6
+    - 7
   # Make sure that cgo is disabled. See: https://golang.org/cmd/cgo/
   env:
     - CGO_ENABLED=0
@@ -60,7 +66,7 @@ archives:
   - id: nix
     builds: [macos, linux]
     # Generate the compresed files based on the following templates
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ .Arm }}"
     # All files will be in a single directory. For example: gatekeeper_0.0.1_linux_amd64
     wrap_in_directory: true
     # Replacement for the Platform name. Instead of have -darwin, replace by macOS


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as much details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
# add arm builds o goreleaser config (fixes #244)

This PR adds builds for linux arm architectures (armv6, ermv7 and arm64)

## Summary 

The goreleaser config was extended to build the binaries for the architectures mentioned above

## Type

Feature request


## Why?

We would like to run gatekeeper on arm boards such as the raspberry py

## Requirements

A arm board (raspberry py)

## How to try it?

Download and run the binary from my fork https://github.com/rekup/gatekeeper/releases/tag/2.1.1

## Documentation

No additional documentation required


## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.

I'm not sure about that. I assume no change is required since I made no change to the codebase of gatekeeper

- [ ] I have updated the documentation/CHANGELOG accordingly.

