### PR TITLE
support SameSite=None #330

### DIFF
--- a/pkg/keycloak/proxy/cookies.go
+++ b/pkg/keycloak/proxy/cookies.go
@@ -59,6 +59,8 @@ func (r *OauthProxy) DropCookie(wrt http.ResponseWriter, host, name, value strin
 		cookie.SameSite = http.SameSiteStrictMode
 	case constant.SameSiteLax:
 		cookie.SameSite = http.SameSiteLaxMode
+	case constant.SameSiteNone:
+		cookie.SameSite = http.SameSiteNoneMode
 	}
 
 	http.SetCookie(wrt, cookie)
@@ -87,6 +89,8 @@ func (r *OauthProxy) GetMaxCookieChunkLength(req *http.Request, cookieName strin
 		maxCookieChunkLength -= len("SameSite=Strict ")
 	case constant.SameSiteLax:
 		maxCookieChunkLength -= len("SameSite=Lax ")
+	case constant.SameSiteNone:
+		maxCookieChunkLength -= len("SameSite=None ")
 	}
 
 	if r.Config.SecureCookie {

--- a/pkg/testsuite/cookies_test.go
+++ b/pkg/testsuite/cookies_test.go
@@ -203,7 +203,7 @@ func TestSameSiteCookie(t *testing.T) {
 	proxy.DropCookie(resp, req.Host, "test-cookie", "test-value", 0)
 
 	assert.Equal(t, resp.Header().Get("Set-Cookie"),
-		"test-cookie=test-value; Path=/",
+		"test-cookie=test-value; Path=/; SameSite=None",
 		"we have not set the cookie, headers: %v", resp.Header())
 }
 


### PR DESCRIPTION
## Summary 
This resolves issue #330 .

## Type

[x] Bug fix
[] Feature request
[] Enhancement
[] Docs

## Why?
Letting a remote client choose a default when there's one specified in the yaml is not okay.

## Checklist:

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.