### PR TITLE
Feat: multi-arch docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ROOT_DIR=${PWD}
 HARDWARE=$(shell uname -m)
 GIT_SHA=$(shell git --no-pager describe --always --dirty)
 BUILD_TIME=$(shell date '+%s')
-VERSION ?= $(shell awk '/release.*=/ { print $$3 }' doc.go | sed 's/"//g')
+VERSION ?= $(shell git describe --abbrev=0 --tags) # fetch the 'nearest' git tag on the current branch
 DEPS=$(shell go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 PACKAGES=$(shell go list ./...)
 LFLAGS ?= -X main.gitsha=${GIT_SHA} -X main.compiled=${BUILD_TIME}

--- a/Makefile
+++ b/Makefile
@@ -34,12 +34,12 @@ static: golang
 
 .PHONY: container-build docker-build
 container-build: docker-build
-docker-build:
+docker-build: ## build the binary inside a container
 	@echo "--> Compiling the project, inside a temporary container"
 	@mkdir -p bin
-	$(eval IMAGE=$(shell uuidgen))
+	$(eval IMAGE=$(shell uuidgen | tr '[:upper:]' '[:lower:]'))
 	${CONTAINER_TOOL} build --target build-env -t ${IMAGE} .
-	${CONTAINER_TOOL} run --rm ${IMAGE} /bin/cat /gatekeeper > bin/gatekeeper
+	${CONTAINER_TOOL} run --rm ${IMAGE} /bin/cat /opt/gatekeeper/gatekeeper > bin/gatekeeper
 	${CONTAINER_TOOL} rmi ${IMAGE}
 	chmod +x bin/gatekeeper
 


### PR DESCRIPTION
# Title

fixes #412

## Summary 

- this pull request changes:
  - the way the version is fetched: before it was on a missing doc.go file and now it is from git
  - the way the gatekeeper binary is fetched when building inside docker; this was broken before
  - the way the container is build with docker/podman; now both amd64/arm64 platforms are supported. There is support for more from docker but I didn't want to stretch this too much.

## Type

[] Bug fix
[] Feature request
[x] Enhancement
[] Docs

## Why?

- Because it is not possible to run the current docker image on arm64 cpus

## Requirements

- podman or docker desktop capable of doing cpu emulation. https://docs.docker.com/build/building/multi-platform/

## How to try it?

- docker run --platform=linux/arm64 -it quay.io/gogatekeeper/gatekeeper:2.9.4 -version

## Documentation

see issue linked above

## Additional Information

- https://docs.podman.io/en/latest/markdown/podman-build.1.html

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

Technically this PR doesn't change the functionality of gogatekeeper so I am unsure wether a new version is required and therefore a corresponding changelog entry

