### PR TITLE
docs: Allowed Query Params for Authentication

### DIFF
--- a/docs/content/userguide/_index.md
+++ b/docs/content/userguide/_index.md
@@ -298,51 +298,33 @@ There are two parameters which you can use to set up cookie names for access tok
 Sometimes you may want to pass some query params to IDP e.g. `kc_idp_hint` or `ui_locales` etc...Gatekeeper provides param `allowed-query-params`
 where you can specify which query params will be forwarded to IDP
 
-This example will allow passing myparam and yourparam with any value to IDP:
+This example will allow passing `myparam` and `yourparam` with any value to IDP:
 
-<<<<<<< HEAD
 ```bash
-=======
-```
->>>>>>> 79855c9ed13894f61e656147fb2b9d062a262e94
-  --allowed-query-params="myparam=" \
-  --allowed-query-params="yourparam="
+  --allowed-query-params="" \
+  --allowed-query-params=""
 ```
 
-<<<<<<< HEAD
 yaml example:
-
 ```yaml
   allowed-query-params:
-    - myparam: ""
-    - yourparam: ""
+    myparam: ""
+    yourparam: ""
 ```
 
-This example will allow passing myparam and yourparam only with specified value:
-
+This example will allow passing `myparam` and `yourparam` only with specified value:
 ```bash
-=======
-This example will allow passing myparam and yourparam only with specified value:
-
-```
->>>>>>> 79855c9ed13894f61e656147fb2b9d062a262e94
   --allowed-query-params="myparam=myvalue" \
   --allowed-query-params="yourparam=yourvalue"
 ```
 
-<<<<<<< HEAD
 yaml example:
-
-yaml example:
-
 ```yaml
   allowed-query-params:
-    - myparam: "myvalue"
-    - yourparam: "yourvalueF"
+    myparam: "myvalue"
+    yourparam: "yourvalueF"
 ```
 
-=======
->>>>>>> 79855c9ed13894f61e656147fb2b9d062a262e94
 ## TCP proxy with HTTP CONNECT
 
 You can protect your TCP services with gogatekeeper by adding `CONNECT` HTTP method to list of `custom-http-methods`. On client side you will need to pass of course token in `Authorization` header (righ now there are few clients which could make HTTP connect with `Bearer` token and then forward tcp, e.g. gost proxy - but only in static way, some IDE provide HTTP CONNECT functionality for db connectors but only with `Basic` authentication, we would like to add this functionality to gatekeeper in future). This setup will authenticate connection at start and will create tunnel to your backend service. Please use with care and ensure that it allows connection only to intended services, otherwise it can be missused for various attacks.


### PR DESCRIPTION
# Fix documentation for "Allowed Query Params for Authentication"

## Summary 
The documentation for allowed query parameters is misleading right now, as it states you should use a yaml list to specify the query parameters you could use. By following the current documentation, GGK simply breaks. 

Also, looks like there are leftovers from conflict resolving on the `_index.md` file currently.

More context here: https://github.com/gogatekeeper/gatekeeper/issues/452#issuecomment-2092443577

## Type
- [ ] Bug fix
- [ ] Feature request
- [ ] Enhancement
- [x] Docs

## Why?
- Better docs

## Requirements
- N/A

## How to try it?
- Just read the changes and check if it's good enough

## Documentation
- N/A

## Additional Information
- N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.
