### PR TITLE
fix: bash allowed-query-params

### DIFF
--- a/docs/content/userguide/_index.md
+++ b/docs/content/userguide/_index.md
@@ -301,8 +301,8 @@ where you can specify which query params will be forwarded to IDP
 This example will allow passing `myparam` and `yourparam` with any value to IDP:
 
 ```bash
-  --allowed-query-params="" \
-  --allowed-query-params=""
+  --allowed-query-params="myparam" \
+  --allowed-query-params="yourparam"
 ```
 
 yaml example:


### PR DESCRIPTION
Messed up on https://github.com/gogatekeeper/gatekeeper/pull/461, my bad

Thanks, @prioliveira for noticing it.