### PR TITLE
Feature/no redirect for ajax

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -79,7 +79,7 @@ upstream-url: http://127.0.0.1:80
 # Returns HTTP 401 when no authentication is present, used with forward proxies or API protection with client credentials grant.
 no-redirects: false
 # Returns HTTP 401 when no authentication is present and the request type is ajax (application/json).
-ajax-no-redirects: false
+ajax-no-redirects: true
 # additional scopes to add to the default (openid+email+profile)
 scopes:
 - vpn-user

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -78,6 +78,8 @@ encryption-key: <ENCRYPTION_KEY>
 upstream-url: http://127.0.0.1:80
 # Returns HTTP 401 when no authentication is present, used with forward proxies or API protection with client credentials grant.
 no-redirects: false
+# Returns HTTP 401 when no authentication is present and the request type is ajax (application/json).
+ajax-no-redirects: false
 # additional scopes to add to the default (openid+email+profile)
 scopes:
 - vpn-user

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -110,6 +110,7 @@ weight: 2
 |	 --enable-hmac                           | enable creating hmac for forwarded requests and verification on incoming requests | false | PROXY_ENABLE_HMAC
 |    --no-proxy value                        | do not proxy requests to upstream, useful for forward-auth usage (with nginx, traefik) | | PROXY_NO_PROXY
 |    --no-redirects                          | do not have back redirects when no authentication is present, 401 them | false | PROXY_NO_REDIRECTS
+|    --ajax-no-redirects                     | do not have back redirects when no authentication is present for AJAX request, 401 them | false | PROXY_AJAX_NO_REDIRECTS
 |    --skip-token-verification               | TESTING ONLY; bypass token verification, only expiration and roles enforced | false | PROXY_SKIP_TOKEN_VERIFICATION
 |    --skip-access-token-issuer-check        | according RFC issuer should not be checked on access token, this will be default true in future | true | PROXY_SKIP_ACCESS_TOKEN_ISSUER_CHECK
 |    --skip-access-token-clientid-check      | according RFC client id should not be checked on access token, this will be default true in future | true | PROXY_SKIP_ACCESS_TOKEN_CLIENT_ID_CHECK

--- a/pkg/google/config/config.go
+++ b/pkg/google/config/config.go
@@ -161,6 +161,7 @@ type Config struct {
 	CorsCredentials                 bool `env:"CORS_CREDENTIALS" json:"cors-credentials" usage:"credentials access control header (Access-Control-Allow-Credentials)" yaml:"cors-credentials"`
 	NoProxy                         bool `env:"NO_PROXY" json:"no-proxy" usage:"do not proxy requests to upstream, useful for forward-auth usage (with nginx, traefik)" yaml:"no-proxy"`
 	NoRedirects                     bool `env:"NO_REDIRECTS" json:"no-redirects" usage:"do not have back redirects when no authentication is present, 401 them" yaml:"no-redirects"`
+	AjaxNoRedirects                 bool `env:"AJAX_NO_REDIRECTS" json:"ajax-no-redirects" usage:"do not have back redirects when no authentication is present and the request type is application/json, 401 them" yaml:"ajax-no-redirects"`
 	SkipTokenVerification           bool `env:"SKIP_TOKEN_VERIFICATION" json:"skip-token-verification" usage:"TESTING ONLY; bypass token verification, only expiration and roles enforced" yaml:"skip-token-verification"`
 	SkipAccessTokenIssuerCheck      bool `env:"SKIP_ACCESS_TOKEN_ISSUER_CHECK" json:"skip-access-token-issuer-check" usage:"according RFC issuer should not be checked on access token, this will be default true in future" yaml:"skip-access-token-issuer-check"`
 	SkipAccessTokenClientIDCheck    bool `env:"SKIP_ACCESS_TOKEN_CLIENT_ID_CHECK" json:"skip-access-token-clientid-check" usage:"according RFC client id should not be checked on access token, this will be default true in future" yaml:"skip-access-token-clientid-check"`

--- a/pkg/keycloak/config/config.go
+++ b/pkg/keycloak/config/config.go
@@ -170,6 +170,7 @@ type Config struct {
 	EnableHmac                      bool `env:"Enable_HMAC" json:"enable-hmac" usage:"enable creating hmac for forwarded requests and verification on incoming requests"`
 	NoProxy                         bool `env:"NO_PROXY" json:"no-proxy" usage:"do not proxy requests to upstream, useful for forward-auth usage (with nginx, traefik)" yaml:"no-proxy"`
 	NoRedirects                     bool `env:"NO_REDIRECTS" json:"no-redirects" usage:"do not have back redirects when no authentication is present, 401 them" yaml:"no-redirects"`
+	AjaxNoRedirects                 bool `env:"AJAX_NO_REDIRECTS" json:"ajax-no-redirects" usage:"do not have back redirects when no authentication is present and the request type is application/json, 401 them" yaml:"ajax-no-redirects"`
 	SkipTokenVerification           bool `env:"SKIP_TOKEN_VERIFICATION" json:"skip-token-verification" usage:"TESTING ONLY; bypass token verification, only expiration and roles enforced" yaml:"skip-token-verification"`
 	SkipAccessTokenIssuerCheck      bool `env:"SKIP_ACCESS_TOKEN_ISSUER_CHECK" json:"skip-access-token-issuer-check" usage:"according RFC issuer should not be checked on access token, this will be default true in future" yaml:"skip-access-token-issuer-check"`
 	SkipAccessTokenClientIDCheck    bool `env:"SKIP_ACCESS_TOKEN_CLIENT_ID_CHECK" json:"skip-access-token-clientid-check" usage:"according RFC client id should not be checked on access token, this will be default true in future" yaml:"skip-access-token-clientid-check"`

--- a/pkg/keycloak/proxy/server.go
+++ b/pkg/keycloak/proxy/server.go
@@ -347,6 +347,7 @@ func (r *OauthProxy) CreateReverseProxy() error {
 
 	redToAuth := core.RedirectToAuthorization(
 		r.Log,
+		r.Config.AjaxNoRedirects,
 		r.Config.NoRedirects,
 		r.Cm,
 		r.Config.SkipTokenVerification,


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as much details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
# Title
Stop redirect with unauthenticated Ajax calls, return 401 instead

## Summary 

Initiation of authentication flow for unauthorised Ajax call generating inconsistent behaviour

## Type

[] Bug fix
[] Feature request
[X] Enhancement
[] Docs

## Why?

Ajax calls are not expected to initiate an authentication flow when there is no active token in the gatekeeper for the request. This is a prevalent issue in case of SPA applications where backend  requests are executed by a http client framework such as axios. An unauthenticated http status code (401) is better understood and handled by these frameworks. Therefore, before initiating the authentication flow, check the request type for Ajax and respond with 401 instead.
To preserve the current behaviour of Ajax requests in the gatekeeper, an additional boolean config is added --ajax-no-redirects; setting to true will only enable the new behaviour to reject unauthenticated Ajax with 401

## Requirements

Gatekeeper ready to serve traffic and Ajax request (type application/json)

## How to try it?

1. Run gatekeeper with flag --ajax-no-redirects: true
2. Make an Ajax request with header `Accept: application/json` 
3. The response should be 401 instead of 303

## Documentation

<!-- 
Link to the documentation pull-request if necessary
-->
--
## Additional Information

Investigation of the issue lead to looking into other similar products and it was found that oauth2-proxy is doing a check for Ajax requests to respond with http status code of 401 where the request is unauthenticated. The same behaviour in gatekeeper would be beneficial when dealing with SPA applications.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

