### PR TITLE
Stop redirect for unauthenticated paths listed in config, return 401 instead

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -78,6 +78,8 @@ encryption-key: <ENCRYPTION_KEY>
 upstream-url: http://127.0.0.1:80
 # Returns HTTP 401 when no authentication is present, used with forward proxies or API protection with client credentials grant.
 no-redirects: false
+# Returns HTTP 401 when no authentication is present for specified set of path regular expressions, used with Ajax / SPA where specific paths do not support authentication flow.
+no-redirect-paths: ["/api/v1/.*"]
 # additional scopes to add to the default (openid+email+profile)
 scopes:
 - vpn-user
@@ -848,6 +850,7 @@ gatekeeper configuration:
   - args:
       - --client-id=dashboard
       - --no-redirects=false # this option will ensure there WILL BE redirects to keycloak server
+      - --no-redirect-paths=["/api/v1/.*"] # this option will ensure there WILL BE NO redirects to keycloak server for specified paths
       - --no-proxy=true # this option will ensure that request will be not forwarded to upstream
       - --listen=0.0.0.0:4180
       - --discovery-url=https://keycloak-dns-name/realms/censored

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -110,6 +110,7 @@ weight: 2
 |	 --enable-hmac                           | enable creating hmac for forwarded requests and verification on incoming requests | false | PROXY_ENABLE_HMAC
 |    --no-proxy value                        | do not proxy requests to upstream, useful for forward-auth usage (with nginx, traefik) | | PROXY_NO_PROXY
 |    --no-redirects                          | do not have back redirects when no authentication is present, 401 them | false | PROXY_NO_REDIRECTS
+|    --no-redirect-paths                     | do not have back redirects when no authentication is present for these paths, 401 them | | PROXY_NO_REDIRECT_PATHS
 |    --skip-token-verification               | TESTING ONLY; bypass token verification, only expiration and roles enforced | false | PROXY_SKIP_TOKEN_VERIFICATION
 |    --skip-access-token-issuer-check        | according RFC issuer should not be checked on access token, this will be default true in future | true | PROXY_SKIP_ACCESS_TOKEN_ISSUER_CHECK
 |    --skip-access-token-clientid-check      | according RFC client id should not be checked on access token, this will be default true in future | true | PROXY_SKIP_ACCESS_TOKEN_CLIENT_ID_CHECK

--- a/pkg/keycloak/config/config.go
+++ b/pkg/keycloak/config/config.go
@@ -127,6 +127,7 @@ type Config struct {
 	ServerReadTimeout               time.Duration     `env:"SERVER_READ_TIMEOUT" json:"server-read-timeout" usage:"the server read timeout on the http server" yaml:"server-read-timeout"`
 	ServerWriteTimeout              time.Duration     `env:"SERVER_WRITE_TIMEOUT" json:"server-write-timeout" usage:"the server write timeout on the http server" yaml:"server-write-timeout"`
 	ServerIdleTimeout               time.Duration     `env:"SERVER_IDLE_TIMEOUT" json:"server-idle-timeout" usage:"the server idle timeout on the http server" yaml:"server-idle-timeout"`
+	NoRedirectPathRegexes           []string          `env:"NO_REDIRECT_PATHS" json:"no-redirect-paths" usage:"do not have back redirects when no authentication is present for these paths, 401 them" yaml:"no-redirect-paths"`
 	Tags                            map[string]string `json:"tags" usage:"keypairs passed to the templates at render,e.g title=Page" yaml:"tags"`
 	DiscoveryURI                    *url.URL
 	OpaAuthzURL                     *url.URL

--- a/pkg/keycloak/proxy/server.go
+++ b/pkg/keycloak/proxy/server.go
@@ -355,6 +355,7 @@ func (r *OauthProxy) CreateReverseProxy() error {
 		r.Config.OAuthURI,
 		r.Config.AllowedQueryParams,
 		r.Config.DefaultAllowedQueryParams,
+		r.Config.NoRedirectPathRegexes,
 	)
 
 	if r.Config.EnableHmac {


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as much details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
# Title
<!-- 
The same title used to create the issue (optional)
-->

## Summary 

Initiation of authentication flow for unauthorised endpoints with content type of application/json/yaml generating inconsistent behaviour.

## Type

[] Bug fix
[] Feature request
[X] Enhancement
[] Docs

## Why?

Ajax calls are not expected to initiate an authentication flow when there is no active token in the gatekeeper for the request. This is a prevalent issue in case of SPA applications where backend requests are executed by a http client framework such as axios. An unauthenticated http status code (401) is better understood and handled by these frameworks. Therefore, before initiating the authentication flow, check the path if it is configured to avoid redirects (config parameter --no-redirect-paths) and respond with 401 instead.

## Requirements

Gatekeeper ready to serve traffic and Ajax request (type application/json)

## How to try it?

1. Run gatekeeper with list of paths for no-redirects --no-redirect-paths: ["^/api/.*$"]
2. Make a request to an endpoint that matches the above path
3. The response should be 401 instead of 303


## Documentation

<!-- 
Link to the documentation pull-request if necessary
-->

## Additional Information

This new PR is raised based on the discussion thread on the PR https://github.com/gogatekeeper/gatekeeper/pull/532. This is an alternate solution where paths with application/json/yaml content which when requested should not be redirected to Keycloak, instead respond with 401

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

