### PR TITLE
Fix duplicated slash in redirect uris when base-uri is set

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -342,6 +342,7 @@ func WithOAuthURI(baseURI string, oauthURI string) func(uri string) string {
 	return func(uri string) string {
 		uri = strings.TrimPrefix(uri, "/")
 		if baseURI != "" {
+			oauthURI = strings.TrimPrefix(oauthURI, "/")
 			return fmt.Sprintf("%s/%s/%s", baseURI, oauthURI, uri)
 		}
 		return fmt.Sprintf("%s/%s", oauthURI, uri)


### PR DESCRIPTION
<!-- 
Please use this template when submitting a new feature request with as much details as possible. Not doing so may result in the issue not being addressed in a timely manner or eventually closed.
-->
# Title
<!-- 
The same title used to create the issue (optional)
-->

## Summary 

<!-- 
A quick summary about the feature request or bug fix with issue number. Ex: Add a new logging system described in #<issue number> 
-->

## Type

[] Bug fix
[] Feature request
[] Enhancement
[] Docs

## Why?

<!-- 
Please elaborate more on why this is needed.
-->

## Requirements

<!-- 
What is required to try it?
-->

## How to try it?

<!-- 
Please provide step by step how to give this PR a try
-->

## Documentation

<!-- 
Link to the documentation pull-request if necessary
-->

## Additional Information

<!-- 
Any additional information that you believe worth mentioning
-->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation or CHANGELOG.
- [ ] I have updated the documentation/CHANGELOG accordingly.

